### PR TITLE
registry refactor, allows removing nodes correct pulling of events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /pkg/
 /spec/reports/
 /tmp/
+/coverage/
 
 # rspec failure tracking
 .rspec_status

--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,1 @@
+--markup=markdown

--- a/README.md
+++ b/README.md
@@ -20,3 +20,40 @@ microservices.
 - pluggable validator
 - multiple services on a node/server
 - all nodes are equal, no master/leader node
+
+
+## Configuration
+
+Moleculer is configured through the Moleculer::config method. Example:
+
+```ruby
+Moleculer.config do |c|
+  c.log_level :debug
+end
+```
+
+### Configuration Options
+
+#### log_level (default: debug)
+Sets the log level of the node. defaults to `:debug`. Can be one of `:trace`, `:debug`, `:info`, `:warn`, `:error`, 
+`:fatal`.
+
+#### node_id (default: \<hostname\>-\<pid\>)
+The node id. Node IDs are required to be unique. In Moleculer-ruby all node ids are suffixed with the PID of the 
+running process, allowing multiple copies of the same node to be run on the same machine. When using a containerized
+environment (i.e. Docker), it is suggested that the node_id also include a random set of characters as there is a chance
+that does running in separate containers can have the same PID.
+
+#### serializer (default: :json)
+Which serializer to use. For more information serializers see [Serialization](https://moleculer.services/docs/0.13/networking.html#Serialization)
+
+#### service_prefix (default: nil)
+The service prefix. This will be prefixed to all services. For example if `service_prefix` were to be `foo` then a
+service whose `service_name` is set to `users` would get the full `service_name` of `foo.users`.
+
+#### timeout (default: 5)
+The Moleculer system timeout. This is used to determine how long a moleculer `call` will wait for a response until it
+times out and throws an error.
+
+#### transporter (default: redis://localhost)
+The transporter Moleculer should use. For more information on transporters see [Transporters](https://moleculer.services/docs/0.13/networking.html#Transporters)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # Moleculer
+[![Build Status](https://travis-ci.org/moleculer-ruby/moleculer.svg?branch=develop)](https://travis-ci.org/moleculer-ruby/moleculer)
+[![Maintainability](https://api.codeclimate.com/v1/badges/d4211bbefca62cb4c10e/maintainability)](https://codeclimate.com/github/moleculer-ruby/moleculer/maintainability)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/d4211bbefca62cb4c10e/test_coverage)](https://codeclimate.com/github/moleculer-ruby/moleculer/test_coverage)
 
 Moleculer is a fast, modern and powerful microservices framework for originally written for [Node.js](). It helps you to 
 build efficient, reliable & scalable services. Moleculer provides many features for building and managing your 

--- a/lib/moleculer.rb
+++ b/lib/moleculer.rb
@@ -75,7 +75,6 @@ module Moleculer
     broker.emit(event, data)
   end
 
-
   # @!attribute log_level [w]
   #   @return [Symbol] the Moleculer log_level. Defaults to `:debug`
 
@@ -102,7 +101,6 @@ module Moleculer
     broker.start
   end
 
-
   ##
   # Stops the moleculer broker.
   def stop
@@ -117,7 +115,7 @@ module Moleculer
   # @example
   #   Moleculer.wait_for_services("some.service", "someother.service")
   def wait_for_services(*services)
-    @broker.wait_for_services(*services)
+    broker.wait_for_services(*services)
   end
 
   # CONFIGURATION
@@ -139,8 +137,8 @@ module Moleculer
     @node_id
   end
 
-  def node_id=(_id)
-    @node_id = "#{@node_id}-#{Process.pid}"
+  def node_id=(id)
+    @node_id = "#{id}-#{Process.pid}"
   end
 
   # @!attribute serializer [r|w]

--- a/lib/moleculer.rb
+++ b/lib/moleculer.rb
@@ -12,26 +12,31 @@ require "moleculer/node"
 require "moleculer/serializers"
 require "moleculer/packets"
 
-# Moleculer is a fast, modern and powerful microservices framework for originally written for [Node.js](). It helps you
-# to build efficient, reliable & scalable services. Moleculer provides many features for building and managing your
-# microservices.
+# Moleculer is a fast, modern and powerful microservices framework for originally written for
+# {Node.js}[https://nodejs.org/en/]. It helps you to build efficient, reliable & scalable services. Moleculer provides
+# many features for building and managing your microservices.
+#
+# This is a Ruby port of the Moleculer protocol, allowing a seamless mesh between NodeJS service nodes, Ruby service
+# nodes, and nodes in other
+# {supported languages}[https://github.com/moleculerjs/awesome-moleculer#polyglot-implementations].
 module Moleculer
   extend self
   PROTOCOL_VERSION = "3".freeze
 
-  attr_writer :node_id,
-              :logger,
-              :log_level,
-              :log,
+  attr_writer :log_level,
+              :heartbeat_interval,
               :serializer,
               :timeout,
-              :transporter,
-              :service_prefix
+              :transporter
 
+  # @return [Symbol] the service prefix. When used will prefix all services name with `<service_prefix>.`, defaults
+  #                  to `nil`
+  attr_accessor :service_prefix
+
+  ##
   # @!attribute broker [r]
-  #   @return [Moleculer::Broker] the moleculer broker instance
-
-
+  #
+  # @return [Moleculer::Broker] the Moleculer Broker instance. Only one broker can exist per node.
   def broker
     @broker ||= Broker.new
   end
@@ -47,77 +52,124 @@ module Moleculer
   # @return [Hash] the request response
   def call(action, params = {}, **kwargs)
     broker.ensure_running
-    if params.empty?
-      return broker.call(action.to_s, kwargs)
-    end
+    return broker.call(action.to_s, kwargs) if params.empty?
+
     broker.call(action.to_s, params, kwargs)
   end
 
+  ##
+  # Allows configuration of moleculer. For more information on configuration see the [Readme](/index.html)
+  #
+  # @yield [self]
   def config
     yield self
   end
 
-  def start
-    broker.start
-  end
-
-  def run
-    broker.run
-  end
-
-  def stop
-    broker.stop
-  end
-
+  ##
+  # Emits the given event to the Moleculer network.
+  #
+  # @param event [String] the name of the event
+  # @param data [Hash] the data related to the event
   def emit(event, data)
     broker.ensure_running
     broker.emit(event, data)
   end
 
-  def heartbeat_interval
-    @heartbeat_interval ||= 5
-  end
 
-  def node_id
-    @node_id ? "#{@node_id}-#{Process.pid}" : "#{Socket.gethostname.downcase}-#{Process.pid}"
-  end
+  # @!attribute log_level [w]
+  #   @return [Symbol] the Moleculer log_level. Defaults to `:debug`
 
-  def services
-    @services ||= []
-  end
-
+  ##
+  # @return [Ougai::Logger] the logging instance for this node. Log level is set to `:debug` by default.
   def logger
     unless @logger
-      @logger = Ougai::Logger.new(@log || STDOUT)
+      @logger           = Ougai::Logger.new(@log || STDOUT)
       @logger.formatter = Ougai::Formatters::Readable.new("MOL")
-      @logger.level = @log_level || :trace
+      @logger.level     = @log_level || :debug
     end
     @logger
   end
 
-  def service_prefix
-    @service_prefix
+  ##
+  # Runs the moleculer broker. This is synchronous and blocks.
+  def run
+    broker.run
   end
 
+  ##
+  # Starts the moleculer broker. This is asynchronous and does not block.
+  def start
+    broker.start
+  end
+
+
+  ##
+  # Stops the moleculer broker.
+  def stop
+    broker.stop
+  end
+
+  ##
+  # Blocks the processes until the requested services have been registered on the network.
+  #
+  # @param services [Array<String>] a list of service to wait for.
+  #
+  # @example
+  #   Moleculer.wait_for_services("some.service", "someother.service")
+  def wait_for_services(*services)
+    @broker.wait_for_services(*services)
+  end
+
+  # CONFIGURATION
+
+  ##
+  # @!attribute heartbeat_interval [r|w]
+  #   @return [Integer] the interval in seconds in which to send M
+  def heartbeat_interval
+    @heartbeat_interval ||= 5
+  end
+
+  ##
+  # @!attribute node_id [r\w]
+  #   @return [String] the Moleculer node id for this running process. Moleculer will automatically append the Process
+  #                    PID to whatever `node_id` is set to, example: `node_id-3232`. Defaults to
+  #                    `Socket.gethostname.downcase`
+  def node_id
+    self.node_id = "#{Socket.gethostname.downcase}-#{Process.pid}" unless @node_id
+    @node_id
+  end
+
+  def node_id=(_id)
+    @node_id = "#{@node_id}-#{Process.pid}"
+  end
+
+  # @!attribute serializer [r|w]
+  #   @return [Symbol] the serialization to use. See [Serializers](https://moleculer.services/docs/0.13/networking.html#Serialization)
   def serializer
     @serializer ||= :json
   end
 
-  def timeout
-    @timeout = 5
+  ##
+  # @!attribute services [r]
+  #   @return [Array<Moleculer::Service>] services to load. To add services push the services you wish to load to the
+  #                                       array.
+  #
+  def services
+    @services ||= []
   end
 
+  ##
+  # @!attribute timeout [r|w]
+  #   @return [Integer] the timeout with which to wait for requests to remote nodes.
+  def timeout
+    @timeout ||= 5
+  end
+
+  ##
+  # @!attribute transporter [r|w]
+  #   @return [String] the fully qualified url for the transporter. See [Transporters](https://moleculer.services/docs/0.13/networking.html#Transporters)
+  #                    for more details.
   def transporter
     @transporter || "redis://localhost"
   end
-
-  def wait_for_services(*services)
-    @broker.wait_for_services(*services)
-  end
-  #
-  #     def register_service(klass)
-  #       services << klass
-  #     end
-  #
-  #   end
 end

--- a/lib/moleculer.rb
+++ b/lib/moleculer.rb
@@ -12,6 +12,9 @@ require "moleculer/node"
 require "moleculer/serializers"
 require "moleculer/packets"
 
+# Moleculer is a fast, modern and powerful microservices framework for originally written for [Node.js](). It helps you
+# to build efficient, reliable & scalable services. Moleculer provides many features for building and managing your
+# microservices.
 module Moleculer
   extend self
   PROTOCOL_VERSION = "3".freeze
@@ -25,20 +28,33 @@ module Moleculer
               :transporter,
               :service_prefix
 
+  # @!attribute broker [r]
+  #   @return [Moleculer::Broker] the moleculer broker instance
+
+
+  def broker
+    @broker ||= Broker.new
+  end
+
+  ##
+  # Calls the given action. This method will block until the timeout is hit (default 5 seconds) or the action returns
+  # a response
+  #
+  # @param action [Symbol] the name of the action to call
+  # @param params [Hash] params to pass to the action
+  # @param kwargs [Hash] call options (see Moleculer::Broker#call)
+  #
+  # @return [Hash] the request response
   def call(action, params = {}, **kwargs)
     broker.ensure_running
     if params.empty?
-      return broker.call(action, kwargs)
+      return broker.call(action.to_s, kwargs)
     end
-    broker.call(action, params, kwargs)
+    broker.call(action.to_s, params, kwargs)
   end
 
   def config
     yield self
-  end
-
-  def broker
-    @broker ||= Broker.new
   end
 
   def start

--- a/lib/moleculer/node.rb
+++ b/lib/moleculer/node.rb
@@ -29,18 +29,30 @@ module Moleculer
       @services[service.name] = service
     end
 
+    ##
+    # @return [Hash] returns a key, value mapping of available actions on this node
+    # TODO: refactor this into a list object
     def actions
       unless @actions
-        map      = @services.values.map { |s| s.actions.keys.map { |key| [key, s.actions[key]] } }.reject(&:empty?)
-        @actions = Hash[*map]
+        @actions = {}
+
+        @services.values.each { |s| s.actions.each { |key, value| @actions[key] = value } }
       end
       @actions
     end
 
+    ##
+    # @return [Hash] returns a key value mapping of events on this node
+    # TODO: refactor this into a list object
     def events
       unless @events
-        map = @services.values.map { |s| s.events.keys.map { |key| [key, s.events[key]] } }.reject(&:empty?)
-        @events = Hash[*map]
+        @events = {}
+        @services.values.map do |s|
+          s.events.each do |key, value|
+            @events[key] ||= []
+            @events[key] << value
+          end
+        end
       end
       @events
     end
@@ -56,11 +68,11 @@ module Moleculer
         ipList:   [],
         hostname: @hostname,
         services: @services.values.map(&:as_json),
-        client: {
-          type: "Ruby",
-          version: Moleculer::VERSION,
+        client:   {
+          type:         "Ruby",
+          version:      Moleculer::VERSION,
           lang_version: RUBY_VERSION,
-        }
+        },
       }
     end
   end

--- a/lib/moleculer/node.rb
+++ b/lib/moleculer/node.rb
@@ -36,7 +36,7 @@ module Moleculer
       unless @actions
         @actions = {}
 
-        @services.values.each { |s| s.actions.each { |key, value| @actions[key] = value } }
+        @services.each_value { |s| s.actions.each { |key, value| @actions[key] = value } }
       end
       @actions
     end
@@ -47,7 +47,7 @@ module Moleculer
     def events
       unless @events
         @events = {}
-        @services.values.map do |s|
+        @services.each_value do |s|
           s.events.each do |key, value|
             @events[key] ||= []
             @events[key] << value

--- a/lib/moleculer/registry.rb
+++ b/lib/moleculer/registry.rb
@@ -7,6 +7,126 @@ module Moleculer
   ##
   # The Registry manages the available services on the network
   class Registry
+    ##
+    # @private
+    class NodeList
+      def initialize
+        @nodes = Concurrent::Hash.new
+      end
+
+      def add_node(node)
+        if @nodes[node.id]
+          @nodes[node.id][:node] = node
+        else
+          @nodes[node.id] = { node: node, last_requested_at: Time.now }
+        end
+      end
+
+      def remove_node(node_id)
+        @nodes.delete(node_id)
+      end
+
+      def fetch_next_node
+        node                                = @nodes.values.min_by { |a| a[:last_requested_at] }[:node]
+        @nodes[node.id][:last_requested_at] = Time.now
+        node
+      end
+
+      def fetch_node(node_id)
+        @nodes.fetch(node_id)[:node]
+      end
+
+      def length
+        @nodes.length
+      end
+    end
+
+    ##
+    # @private
+    class ActionList
+      def initialize
+        @actions = Concurrent::Hash.new
+      end
+
+      def add(action)
+        name             = "#{action.service.service_name}.#{action.name}"
+        @actions[name] ||= NodeList.new
+        @actions[name].add_node(action.node)
+      end
+
+      def remove_node(node_id)
+        @actions.each do |k, a|
+          a.remove_node(node_id)
+          @actions.delete(k) if a.length.zero?
+        end
+      end
+
+      def fetch_action(action_name)
+        raise Errors::ActionNotFound, "The action '#{action_name}' was not found." unless @actions[action_name]
+
+        @actions[action_name].fetch_next_node.actions[action_name]
+      end
+    end
+
+    ##
+    # @private
+    class EventList
+      ##
+      # @private
+      class Item
+        def initialize
+          @services = Concurrent::Hash.new
+        end
+
+        def add_service(service)
+          @services[service.service_name] ||= NodeList.new
+          @services[service.service_name].add_node(service.node)
+        end
+
+        def fetch_nodes
+          @services.values.map(&:fetch_next_node)
+        end
+
+        def remove_node(node_id)
+          @services.each do |k, list|
+            list.remove_node(node_id)
+            @services.delete(k) if list.length.zero?
+          end
+        end
+
+        def length
+          @services.map(&:length).inject(0) { |s, a| s + a }
+        end
+      end
+
+      def initialize
+        @events = Concurrent::Hash.new
+      end
+
+      def add(event)
+        name            = event.name
+        @events[name] ||= Item.new
+        @events[name].add_service(event.service)
+      end
+
+      def remove_node(node_id)
+        @events.each do |k, item|
+          item.remove_node(node_id)
+          @events.delete(k) if item.length.zero?
+        end
+      end
+
+      def fetch_events(event_name)
+        return [] unless @events[event_name]
+
+        @events[event_name].fetch_nodes.map { |n| n.events[event_name] }.flatten
+      end
+    end
+
+    private_constant :ActionList
+    private_constant :EventList
+    private_constant :NodeList
+
     include Support
 
     attr_reader :local_node
@@ -14,12 +134,13 @@ module Moleculer
     ##
     # @param [Moleculer::Broker] broker the service broker instance
     def initialize(broker)
-      @broker   = broker
-      @nodes    = Concurrent::Hash.new
-      @actions  = Concurrent::Hash.new
-      @events   = Concurrent::Hash.new
-      @services = Concurrent::Hash.new
-      @logger   = Moleculer.logger
+      @broker           = broker
+      @nodes            = NodeList.new
+      @actions          = ActionList.new
+      @events           = EventList.new
+      @services         = Concurrent::Hash.new
+      @logger           = Moleculer.logger
+      @remove_semaphore = Concurrent::Semaphore.new(1)
     end
 
     ##
@@ -38,8 +159,7 @@ module Moleculer
         @local_node = node
       end
       @logger.info "registering node #{node.id}" unless node.local?
-      @nodes[node.id] = { node: node }
-      update_node_for_load_balancer(node)
+      @nodes.add_node(node)
       update_services(node)
       update_actions(node)
       update_events(node)
@@ -54,26 +174,32 @@ module Moleculer
     #
     # @return [Moleculer::Service::Action|Moleculer::RemoteService::Action]
     def fetch_action(action_name)
-      node = fetch_next_node_for_action(action_name)
-      fetch_action_from_node(action_name, node)
+      @actions.fetch_action(action_name)
     end
 
-    def fetch_events(event_name)
-      nodes = fetch_next_nodes_for_event(event_name)
-      nodes.map { |node| fetch_event_from_node(event_name, node) }
+    def fetch_events_for_emit(event_name)
+      @events.fetch_events(event_name)
     end
 
-    def fetch_events_for_node_id(event_name, node_id)
-      node = @nodes.fetch(node_id)[:node]
-      node.services.values.map { |s| s.events.values }.flatten.select { |e| e.name == event_name }
-    end
-
+    ##
+    # It fetches the given node, and raises an exception if the node does not exist
+    #
+    # @param node_id [String] the id of the node to fetch
+    #
+    # @return [Moleculer::Node] the moleculer node with the given id
+    # @raise [Moleculer::Errors::NodeNotFound] if the node was not found
     def fetch_node(node_id)
-      @nodes.fetch(node_id)[:node]
+      @nodes.fetch_node(node_id)
     rescue KeyError
       raise Errors::NodeNotFound, "The node with the id '#{node_id}' was not found."
     end
 
+    ##
+    # Fetches the given node, and returns nil if the node was not found
+    #
+    # @param node_id [String] the id of the node to fetch
+    #
+    # @return [Moleculer::Node] the moleculer node with the given id
     def safe_fetch_node(node_id)
       fetch_node(node_id)
     rescue Errors::NodeNotFound
@@ -99,6 +225,20 @@ module Moleculer
       services - @services.keys
     end
 
+    ##
+    # Removes the node with the given id. Because this must act across multiple indexes this action uses a semaphore to
+    # reduce the chance of race conditions.
+    #
+    # @param node_id [String] the node to remove
+    def remove_node(node_id)
+      @remove_semaphore.acquire
+      @logger.info "removing node '#{node_id}'"
+      @nodes.remove_node(node_id)
+      @actions.remove_node(node_id)
+      @events.remove_node(node_id)
+      @remove_semaphore.release
+    end
+
     private
 
     def get_local_action(name)
@@ -109,20 +249,10 @@ module Moleculer
       @nodes[node.id][:last_called_at] = Time.now
     end
 
-    def fetch_action_from_node(action_name, node)
-      node.actions.fetch(action_name)
-    rescue KeyError
-      raise(Errors::ActionNotFound, "The action '#{action_name}' was found on the node with id '#{node.id}'")
-    end
-
     def fetch_event_from_node(event_name, node)
       node.events.fetch(event_name)
     rescue KeyError
       raise Errors::EventNotFound, "The event '#{event_name}' was not found on the node id with id '#{node.id}'"
-    end
-
-    def fetch_next_node_for_action(action_name)
-      fetch_node_list_for_action(action_name).min_by { |a| a[:last_called_at] }[:node]
     end
 
     def fetch_next_nodes_for_event(event_name)
@@ -132,51 +262,33 @@ module Moleculer
       nodes.map { |node_list| node_list.min_by { |a| a[:last_called_at] }[:node] }
     end
 
-    def fetch_node_list_for_action(action_name)
-      node_list = HashUtil.fetch(@actions, action_name)
-      node_list.collect { |name| @nodes[name] }
-    rescue KeyError
-      raise Errors::ActionNotFound, "The action '#{action_name}' was not found"
+    def remove_node_from_events(node_id)
+      @events.values.each do |event|
+        event.values.each do |list|
+          list.reject! { |id| id == node_id }
+        end
+      end
     end
 
     def update_actions(node)
       node.actions.values.each do |action|
-        replace_action(action, node)
+        @actions.add(action)
       end
       @logger.debug "registered #{node.actions.length} action(s) for node '#{node.id}'"
     end
 
     def update_events(node)
-      node.services.values.each do |service|
-        service.events.values.each do |event|
-          replace_event(event, service, node)
-        end
+      node.events.values.each do |events|
+        events.each { |e| @events.add(e) }
       end
       @logger.debug "registered #{node.events.length} event(s) for node '#{node.id}'"
     end
 
     def update_services(node)
       node.services.values.each do |service|
-        replace_service(service, node)
+        @services[service.service_name] ||= NodeList.new
+        @services[service.service_name].add_node(node)
       end
-    end
-
-    def replace_service(service, node)
-      @services[service.service_name] ||= []
-      nodes                             = @services[service.service_name].reject! { |a| a == node.id }
-      @logger.info "registered new service '#{service.service_name}'" unless nodes
-      @services[service.service_name] << node.id
-    end
-
-    def replace_action(action, node)
-      @actions[action.name] ||= Concurrent::Array.new
-      @actions[action.name] << node.id unless @actions[action.name].include?(node.id)
-    end
-
-    def replace_event(event, service, node) # rubocop:disable Metric/AbcSize
-      @events[event.name]                       ||= Concurrent::Hash.new
-      @events[event.name][service.service_name] ||= Concurrent::Array.new
-      @events[event.name][service.service_name] << node.id unless @events[event.name][service.service_name].include?(node.id)
     end
   end
 end

--- a/lib/moleculer/registry.rb
+++ b/lib/moleculer/registry.rb
@@ -177,6 +177,13 @@ module Moleculer
       @actions.fetch_action(action_name)
     end
 
+    ##
+    # Fetches all the events for the given event name that should be used to emit an event. This is load balanced, and
+    # will fetch a different node for nodes that duplicate the service/event
+    #
+    # @param event_name [String] the name of the even to fetch
+    #
+    # @return [Array<Moleculer::Service::Event>] the events that that should be emitted to
     def fetch_events_for_emit(event_name)
       @events.fetch_events(event_name)
     end

--- a/lib/moleculer/service/action.rb
+++ b/lib/moleculer/service/action.rb
@@ -9,7 +9,7 @@ module Moleculer
 
       # @!attribute [r] name
       #   @return [String] the name of the action
-      attr_reader :name
+      attr_reader :name, :service
 
       ##
       # @param name [String|Symbol] the name of the action.

--- a/lib/moleculer/service/event.rb
+++ b/lib/moleculer/service/event.rb
@@ -5,8 +5,6 @@ module Moleculer
     ##
     # Represents a service event.
     class Event
-      include Support
-
       # @!attribute [r] name
       #   @return [String] the name of the action
       attr_reader :name

--- a/lib/moleculer/service/event.rb
+++ b/lib/moleculer/service/event.rb
@@ -7,7 +7,9 @@ module Moleculer
     class Event
       # @!attribute [r] name
       #   @return [String] the name of the action
-      attr_reader :name
+      # @!attribute [r] service
+      #   @return [Moleculer::Service] the service that this event is tied to
+      attr_reader :name, :service
 
       ##
       # @param name [String] the name of the action

--- a/spec/moleculer/moleculer_spec.rb
+++ b/spec/moleculer/moleculer_spec.rb
@@ -1,0 +1,8 @@
+RSpec.describe Moleculer do
+  let(:broker) { instance_double(Moleculer::Broker) }
+  describe "#call" do
+    it "ensures the broker is running" do
+
+    end
+  end
+end

--- a/spec/moleculer/moleculer_spec.rb
+++ b/spec/moleculer/moleculer_spec.rb
@@ -1,8 +1,40 @@
 RSpec.describe Moleculer do
-  let(:broker) { instance_double(Moleculer::Broker) }
-  describe "#call" do
-    it "ensures the broker is running" do
+  let(:broker) { instance_double(Moleculer::Broker, ensure_running: true, call: true) }
 
+  describe "#broker" do
+    it "returns a new instance of the broker when first called" do
+      expect(subject.broker).to be_a(Moleculer::Broker)
     end
+
+    it "returns the same instance of the broker every time it is called" do
+      broker = subject.broker
+      expect(subject.broker).to eq broker
+    end
+  end
+
+  describe "#call" do
+    before :each do
+      allow(subject).to receive(:broker).and_return(broker)
+    end
+
+    it "ensures the broker is running" do
+      subject.call("an_action")
+      expect(broker).to have_received(:ensure_running)
+    end
+
+    it "passes the call arguments to the broker #call method" do
+      subject.call(:an_action, foo: "bar")
+      expect(broker).to have_received(:call).with("an_action", foo: "bar")
+    end
+
+    it "passes options to the broker #call function" do
+      subject.call(:an_action, { foo: "bar" }, node_id: "node", meta: { meta: true }, timeout: 5)
+      expect(broker).to have_received(:call)
+        .with("an_action", { foo: "bar" }, node_id: "node", meta: { meta: true }, timeout: 5)
+    end
+  end
+
+  describe "#config" do
+
   end
 end

--- a/spec/moleculer/moleculer_spec.rb
+++ b/spec/moleculer/moleculer_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Moleculer do
     end
 
     after :each do
-      %w[node_id log_level serializer timeout transporter service_prefix logger].each do |v|
+      %w[node_id log_level serializer heartbeat_interval services timeout transporter service_prefix logger].each do |v|
         if Moleculer.send(:instance_variable_get, "@#{v}".to_sym)
           Moleculer.send(:remove_instance_variable, "@#{v}".to_sym)
         end
@@ -65,6 +65,8 @@ RSpec.describe Moleculer do
         c.timeout        = 100
         c.transporter    = "some_transporter"
         c.service_prefix = "service"
+        c.heartbeat_interval = 10
+        c.services << Moleculer::Service::Base
       end
 
       expect(subject.node_id).to include("test")
@@ -73,6 +75,8 @@ RSpec.describe Moleculer do
       expect(subject.timeout).to eq 100
       expect(subject.transporter).to eq "some_transporter"
       expect(subject.service_prefix).to eq "service"
+      expect(subject.heartbeat_interval).to eq 10
+      expect(subject.services).to include(Moleculer::Service::Base)
     end
 
     it "should have the correct defaults" do
@@ -82,6 +86,8 @@ RSpec.describe Moleculer do
       expect(subject.timeout).to eq 5
       expect(subject.transporter).to eq "redis://localhost"
       expect(subject.service_prefix).to be_nil
+      expect(subject.heartbeat_interval).to eq 5
+      expect(subject.services).to eq []
     end
   end
 

--- a/spec/moleculer/node_spec.rb
+++ b/spec/moleculer/node_spec.rb
@@ -1,0 +1,65 @@
+RSpec.describe Moleculer::Node do
+  let(:service_1) do
+    Class.new(Moleculer::Service::Base) do
+      service_name "service-1"
+      action "test", :action_1
+      action "another_test", :action_2
+      event "something.happened", :event_1
+      event "something-else.happened", :event_2
+
+      def action_1; end
+
+      def action_2; end
+
+      def event_1; end
+
+      def event_2; end
+    end
+  end
+
+  let(:action_1_1) { service_1.actions.values.first }
+  let(:action_1_2) { service_1.actions.values.last }
+  let(:event_1_1)  { service_1.events.values.first }
+  let(:event_1_2)  { service_1.events.values.last  }
+
+  let(:service_2) do
+    Class.new(Moleculer::Service::Base) do
+      service_name "service-2"
+      action "test", :action_1
+      event "something.happened", :event_1
+
+      def action_1; end
+
+      def event_1; end
+    end
+  end
+
+  let(:action_2_1) { service_2.actions.values.last }
+  let(:event_2_1)  { service_2.events.values.last }
+
+  subject do
+    Moleculer::Node.new(
+      node_id:  "test-node",
+      services: [service_1, service_2],
+    )
+  end
+
+  describe "#actions" do
+    it "should return the services actions" do
+      expect(subject.actions).to eq(
+        "service-1.test"         => action_1_1,
+        "service-1.another_test" => action_1_2,
+        "service-2.test"         => action_2_1,
+      )
+    end
+  end
+
+  describe "#events" do
+    it "should return all events for all services" do
+      expect(subject.events).to eq(
+        "something.happened"      => [event_1_1, event_2_1],
+        "something-else.happened" => [event_1_2],
+      )
+    end
+  end
+end

--- a/spec/moleculer/registry_spec.rb
+++ b/spec/moleculer/registry_spec.rb
@@ -1,0 +1,116 @@
+RSpec.describe Moleculer::Registry do
+  let(:service_1_1) do
+    Class.new(Moleculer::Service::Base) do
+      service_name "service-1"
+      action "test", :action_1
+      action "test2", :action_2
+      event "test.update", :event_1
+
+      def action_1; end
+
+      def action_2; end
+
+      def event_1; end
+    end
+  end
+
+  let(:service_1_2) do
+    Class.new(Moleculer::Service::Base) do
+      service_name "service-1-2"
+      event "test.update", :event_1
+
+      def event_1; end
+    end
+  end
+
+  let(:action_1_1) { service_1_1.actions.values.first }
+  let(:event_1_1) { service_1_1.events.values.first }
+  let(:event_1_2) { service_1_2.events.values.first }
+
+  let(:service_2_1) do
+    Class.new(Moleculer::Service::Base) do
+      service_name "service-1"
+      action "test", :action_1
+      event "test.update", :event_1
+
+      def action_1; end
+
+      def event_1; end
+    end
+  end
+
+  let(:action_2_1) { service_2_1.actions.values.first }
+  let(:event_2_1) { service_2_1.events.values.first }
+
+  let(:node_1) do
+    Moleculer::Node.new(
+      node_id:  "node-1",
+      services: [service_1_1, service_1_2],
+    )
+  end
+
+  let(:node_2) do
+    Moleculer::Node.new(
+      node_id:  "node-2",
+      services: [service_2_1],
+    )
+  end
+
+  let(:broker) { instance_double(Moleculer::Broker) }
+
+  subject { Moleculer::Registry.new(broker) }
+
+  before :each do
+    allow(service_1_2).to receive(:node).and_return(node_1)
+    allow(service_1_1).to receive(:node).and_return(node_1)
+    allow(service_2_1).to receive(:node).and_return(node_2)
+    subject.register_node(node_1)
+    subject.register_node(node_2)
+  end
+
+  describe "#fetch_action" do
+    it "retrieves the action in round robin fashion" do
+      expect(subject.fetch_action("service-1.test")).to eq(action_1_1)
+      expect(subject.fetch_action("service-1.test")).to eq(action_2_1)
+      expect(subject.fetch_action("service-1.test")).to eq(action_1_1)
+    end
+  end
+
+  describe "#fetch_events_for_emit" do
+    it "retrieves the load balanced events for the given name" do
+      expect(subject.fetch_events_for_emit("test.update")).to include(event_1_1, event_1_2)
+      expect(subject.fetch_events_for_emit("test.update")).to include(event_2_1, event_1_2)
+    end
+  end
+
+  describe "fetch_node" do
+    it "retrieves the node for the given id" do
+      expect(subject.fetch_node("node-1")).to eq(node_1)
+    end
+
+    it "raises an exception if the node was not found" do
+      expect {subject.fetch_node("not-a-node")}.to raise_error(Moleculer::Errors::NodeNotFound)
+    end
+  end
+
+  describe "#safe_fetch_node" do
+    it "retrieves the node for the given id" do
+      expect(subject.safe_fetch_node("node-1")).to eq(node_1)
+    end
+
+    it "returns nil if the node was not found" do
+      expect(subject.safe_fetch_node("not-a-node")).to be_nil
+    end
+  end
+
+  describe "#remove_node" do
+    it "removes the node from the registry" do
+      subject.remove_node("node-1")
+      expect(subject.safe_fetch_node("node-1")).to be_nil
+      expect { subject.fetch_action("service-1.test2") }.to raise_error(Moleculer::Errors::ActionNotFound)
+      expect(subject.fetch_events_for_emit("test.update")).to_not include(event_1_1)
+      subject.remove_node("node-2")
+      subject.fetch_events_for_emit("test.update")
+    end
+  end
+end

--- a/spec/moleculer/service/event_spec.rb
+++ b/spec/moleculer/service/event_spec.rb
@@ -1,4 +1,26 @@
 RSpec.describe Moleculer::Service::Event do
-  let(:service) { instance_double(Moleculer::Service::Base) }
+  let(:service_instance) { double(Moleculer::Service::Base, some_method: true) }
+  let(:service) { class_double(Moleculer::Service::Base, new: service_instance, node: node) }
   let(:node) { instance_double(Moleculer::Node) }
+
+  subject { Moleculer::Service::Event.new("event.name", service, :some_method, some: "options") }
+
+  describe "#execute" do
+    it "sends the method with the provided argument" do
+      subject.execute(foo: "bar")
+      expect(service_instance).to have_received(:some_method).with(foo: "bar")
+    end
+  end
+
+  describe "#node" do
+    it "returns the service's node" do
+      expect(subject.node).to eq node
+    end
+  end
+
+  describe "#as_json" do
+    it "returns the correct json for the event" do
+      expect(subject.as_json).to eq(name: subject.name)
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,11 @@
 require "bundler/setup"
 require "moleculer"
+require 'simplecov'
+
 
 RSpec.configure do |config|
+  SimpleCov.start
+
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"
 


### PR DESCRIPTION
this refactor allows nodes to be deleted from the registry, and significantly decreases how brittle the previous implementation was.