### PR TITLE
This moves the publishing (and some of the processing) logic into it's own helper class

### DIFF
--- a/lib/moleculer/broker.rb
+++ b/lib/moleculer/broker.rb
@@ -19,6 +19,7 @@ module Moleculer
     attr_reader :config, :logger, :transporter, :registry
 
     def_delegators :@config, :node_id, :heartbeat_interval, :services, :service_prefix
+    def_delegators :@publisher, :publish_event
 
     ##
     # @param config [Moleculer::Config] the broker configuration
@@ -159,18 +160,6 @@ module Moleculer
       )
     end
 
-    ##
-    # @return [Proc] returns the rescue_action if defined on the configuration
-    def rescue_action
-      config.rescue_action
-    end
-
-    ##
-    # @return [Proc] returns the rescue_event if defined on the configuration
-    def rescue_event
-      config.rescue_event
-    end
-
     private
 
     def handle_signal(sig)
@@ -179,10 +168,6 @@ module Moleculer
         raise Interrupt
       end
     end
-
-
-
-
 
     ##
     # Publishes the info packet to either all nodes, or the given node

--- a/lib/moleculer/broker.rb
+++ b/lib/moleculer/broker.rb
@@ -199,7 +199,7 @@ module Moleculer
     def start_heartbeat
       @logger.trace "starting heartbeat timer"
       Concurrent::TimerTask.new(execution_interval: heartbeat_interval) do
-        publish_heartbeat
+        @publisher.publish_heartbeat
         @registry.expire_nodes
       end.execute
     end

--- a/lib/moleculer/broker.rb
+++ b/lib/moleculer/broker.rb
@@ -3,6 +3,7 @@
 require "forwardable"
 
 require_relative "broker/message_processor"
+require_relative "broker/publisher"
 require_relative "registry"
 require_relative "transporters"
 require_relative "support"
@@ -15,7 +16,7 @@ module Moleculer
   class Broker
     include Moleculer::Support
     extend Forwardable
-    attr_reader :config, :logger
+    attr_reader :config, :logger, :transporter, :registry
 
     def_delegators :@config, :node_id, :heartbeat_interval, :services, :service_prefix
 
@@ -179,32 +180,9 @@ module Moleculer
       end
     end
 
-    def publish(packet_type, message = {})
-      packet = Packets.for(packet_type).new(@config, message.merge(sender: @registry.local_node.id))
-      @transporter.publish(packet)
-    end
 
-    def publish_event(event_data)
-      publish_to_node(:event, event_data.delete(:node), event_data)
-    end
 
-    def publish_heartbeat
-      @logger.trace "publishing hearbeat"
-      publish(:heartbeat)
-    end
 
-    ##
-    # Publishes the discover packet
-    def publish_discover
-      @logger.trace "publishing discover request"
-      publish(:discover)
-    end
-
-    ##
-    # Publish targeted discovery to node
-    def publish_discover_to_node_id(node_id)
-      publish_to_node_id(:discover, node_id)
-    end
 
     ##
     # Publishes the info packet to either all nodes, or the given node

--- a/lib/moleculer/broker/message_processor.rb
+++ b/lib/moleculer/broker/message_processor.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Moleculer
+  class Broker
+    ##
+    # A Helper that encapsulates message processing logic
+    # @private
+    module MessageProcessor
+      extend self
+
+      ##
+      # Processes an RPC response
+      # @param context [Context] the call context
+      # @param packet [Packet::Base] the message packet
+      def process_rpc_response(context, packet)
+        context[:future].fulfill(packet.data)
+      end
+    end
+  end
+end

--- a/lib/moleculer/broker/publisher.rb
+++ b/lib/moleculer/broker/publisher.rb
@@ -13,26 +13,26 @@ module Moleculer
       ##
       # Publishes an event
       # @param event_data [Hash] the event data to publish
-      def publish_event(event_data)
+      def event(event_data)
         publish_to_node(:event, event_data.delete(:node), event_data)
       end
 
       ##
       # Publishes a heartbeat packet to all nodes
-      def publish_heartbeat
+      def heartbeat
         publish(:heartbeat)
       end
 
       ##
       # Publishes the discover packet to all nodes
-      def publish_discover
+      def discover
         publish(:discover)
       end
 
       ##
       # Publish targeted discovery to node
       # @param node_id [String] the node to publish the discover packet to
-      def publish_discover_to_node_id(node_id)
+      def discover_to_node_id(node_id)
         publish_to_node_id(:discover, node_id)
       end
 
@@ -42,7 +42,7 @@ module Moleculer
       # @param force [Boolean] allows an info packet to be published to a node even if the node is not listed in the
       #                        node registry
       # TODO: refactor this into more than one method to reduce the logic tree
-      def publish_info(node_id = nil, force = false)
+      def info(node_id = nil, force = false)
         return publish(:info, @broker.registry.local_node.to_h) unless node_id
 
         node = @broker.registry.safe_fetch_node(node_id)
@@ -58,14 +58,14 @@ module Moleculer
       ##
       # Publishes an RPC request
       # @param request_data [Hash] the request data to publish to the node
-      def publish_req(request_data)
+      def req(request_data)
         publish_to_node(:req, request_data.delete(:node), request_data)
       end
 
       ##
       # Publishes an RPC response to the requesting node
       # @param response_data [Hash] the response data to publish
-      def publish_res(response_data)
+      def res(response_data)
         publish_to_node(:res, response_data.delete(:node), response_data)
       end
 

--- a/lib/moleculer/broker/publisher.rb
+++ b/lib/moleculer/broker/publisher.rb
@@ -18,13 +18,15 @@ module Moleculer
         publish_to_node(:event, event_data.delete(:node), event_data)
       end
 
+      ##
+      # Publishes a heartbeat packet to all nodes
       def publish_heartbeat
         @broker.logger.trace "publishing heartbeat"
         publish(:heartbeat)
       end
 
       ##
-      # Publishes the discover packet
+      # Publishes the discover packet to all nodes
       def publish_discover
         @broker.logger.trace "publishing discover request"
         publish(:discover)
@@ -34,6 +36,32 @@ module Moleculer
       # Publish targeted discovery to node
       def publish_discover_to_node_id(node_id)
         publish_to_node_id(:discover, node_id)
+      end
+
+      ##
+      # Publishes the info packet to either all nodes, or the given node
+      # @param node_id [String] the node id to publish to
+      # @param force [Boolean] allows an info packet to be published to a node even if the node is not listed in the
+      #                        node registry
+      def publish_info(node_id = nil, force = false)
+        return publish(:info, @broker.registry.local_node.to_h) unless node_id
+
+        node = @broker.registry.safe_fetch_node(node_id)
+        if node
+          publish_to_node(:info, node, @broker.registry.local_node.to_h)
+        elsif force
+          ## in rare cases there may be a lack of synchronization between brokers, if we can't find the node in the
+          # registry we will attempt to force publish it (if force is true)
+          publish_to_node_id(:info, node_id, @broker.registry.local_node.to_h)
+        end
+      end
+
+      def publish_req(request_data)
+        publish_to_node(:req, request_data.delete(:node), request_data)
+      end
+
+      def publish_res(response_data)
+        publish_to_node(:res, response_data.delete(:node), response_data)
       end
 
       private
@@ -47,8 +75,6 @@ module Moleculer
         packet = Packets.for(packet_type).new(@broker.config, message.merge(node: node))
         @broker.transporter.publish(packet)
       end
-
-
     end
   end
 end

--- a/lib/moleculer/broker/publisher.rb
+++ b/lib/moleculer/broker/publisher.rb
@@ -21,14 +21,12 @@ module Moleculer
       ##
       # Publishes a heartbeat packet to all nodes
       def publish_heartbeat
-        @broker.logger.trace "publishing heartbeat"
         publish(:heartbeat)
       end
 
       ##
       # Publishes the discover packet to all nodes
       def publish_discover
-        @broker.logger.trace "publishing discover request"
         publish(:discover)
       end
 
@@ -88,6 +86,8 @@ module Moleculer
 
       def publish_packet_for(packet_type, message)
         packet = Packets.for(packet_type).new(@broker.config, message)
+        @broker.logger.trace("publishing '#{packet_type}'")
+        @broker.logger.trace(packet.to_h)
         @broker.transporter.publish(packet)
       end
     end

--- a/lib/moleculer/broker/publisher.rb
+++ b/lib/moleculer/broker/publisher.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module Moleculer
+  class Broker
+    ##
+    # Handles the publishing of messages to the transporter
+    class Publisher
+
+      # @param broker [Broker] the broker instance
+      def initialize(broker)
+        @broker = broker
+      end
+
+      ##
+      # Publishes an event
+      # @param event_data [Hash] the event data to publish
+      def publish_event(event_data)
+        publish_to_node(:event, event_data.delete(:node), event_data)
+      end
+
+      def publish_heartbeat
+        @broker.logger.trace "publishing heartbeat"
+        publish(:heartbeat)
+      end
+
+      ##
+      # Publishes the discover packet
+      def publish_discover
+        @broker.logger.trace "publishing discover request"
+        publish(:discover)
+      end
+
+      ##
+      # Publish targeted discovery to node
+      def publish_discover_to_node_id(node_id)
+        publish_to_node_id(:discover, node_id)
+      end
+
+      private
+
+      def publish(packet_type, message = {})
+        packet = Packets.for(packet_type).new(@broker.config, message.merge(sender: @broker.registry.local_node.id))
+        @broker.transporter.publish(packet)
+      end
+
+      def publish_to_node(packet_type, node, message = {})
+        packet = Packets.for(packet_type).new(@broker.config, message.merge(node: node))
+        @broker.transporter.publish(packet)
+      end
+
+
+    end
+  end
+end

--- a/lib/moleculer/broker/publisher.rb
+++ b/lib/moleculer/broker/publisher.rb
@@ -5,7 +5,6 @@ module Moleculer
     ##
     # Handles the publishing of messages to the transporter
     class Publisher
-
       # @param broker [Broker] the broker instance
       def initialize(broker)
         @broker = broker

--- a/lib/moleculer/service/remote.rb
+++ b/lib/moleculer/service/remote.rb
@@ -42,7 +42,7 @@ module Moleculer
             next if Support::HashUtil.fetch(a, :name) =~ /^\$/
 
             define_method("action_#{seq}".to_sym) do |ctx|
-              @broker.send(:publish_req,
+              @broker.send(:req,
                            id:         ctx.id,
                            action:     ctx.action.name,
                            params:     ctx.params,
@@ -63,7 +63,7 @@ module Moleculer
           Support::HashUtil.fetch(service_info, :events).values.each do |a|
             name = Support::HashUtil.fetch(a, :name)
             define_method("event_#{seq}".to_sym) do |data|
-              @broker.send(:publish_event,
+              @broker.send(:event,
                            event:     name,
                            data:      data,
                            broadcast: false,

--- a/lib/moleculer/transporters/fake.rb
+++ b/lib/moleculer/transporters/fake.rb
@@ -22,7 +22,6 @@ module Moleculer
       end
 
       def publish(packet)
-        @logger.debug "publishing packet to '#{packet.topic}'", packet.to_h
         @logger.debug "processing #{@@subscriptions[packet.topic].length} callbacks for '#{packet.topic}'"
         @@subscriptions[packet.topic].each { |c| c.call(packet) }
       end

--- a/spec/moleculer/broker/messages_processor_spec.rb
+++ b/spec/moleculer/broker/messages_processor_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+RSpec.describe Moleculer::Broker::MessageProcessor do
+  describe "#process_rpc_request" do
+    let(:context) { { future: double("Future", fulfill: true) } }
+    let(:data)    { {} }
+    let(:packet)  { double(Moleculer::Packets::Res, data: data) }
+
+    it "calls fulfill on the context future with the packet data" do
+      subject.process_rpc_response(context, packet)
+      expect(context[:future]).to have_received(:fulfill).with(packet.data)
+    end
+  end
+end

--- a/spec/moleculer/broker/publisher_spec.rb
+++ b/spec/moleculer/broker/publisher_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Moleculer::Broker::Publisher do
 
   describe "#publish_req" do
     it "publishes an info packet to the transporter" do
-      subject.publish_req({})
+      subject.publish_req(id: "anid", action: "test", data: {}, meta: {}, params: {})
       expect(transporter).to have_received(:publish)
         .with(instance_of(Moleculer::Packets::Req))
     end

--- a/spec/moleculer/broker/publisher_spec.rb
+++ b/spec/moleculer/broker/publisher_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require_relative "../../../lib/moleculer/transporters/base"
+
+RSpec.describe Moleculer::Broker::Publisher do
+  let(:transporter) { double(Moleculer::Transporters::Base, publish: true) }
+  let(:broker) do
+    double(Moleculer::Broker,
+           config:      Moleculer::Configuration.new,
+           transporter: transporter)
+  end
+
+  subject { Moleculer::Broker::Publisher.new(broker) }
+
+  describe "#publish_event" do
+    let(:event) { { event: "test.event", data: {}, broadcast: false} }
+
+    it "publishes an event packet to the transporter" do
+      subject.publish_event(event)
+      expect(transporter).to have_received(:publish)
+        .with(instance_of(Moleculer::Packets::Event))
+    end
+  end
+end

--- a/spec/moleculer/broker/publisher_spec.rb
+++ b/spec/moleculer/broker/publisher_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Moleculer::Broker::Publisher do
     let(:event) { { event: "test.event", data: {}, broadcast: false } }
 
     it "publishes an event packet to the transporter" do
-      subject.publish_event(event)
+      subject.event(event)
       expect(transporter).to have_received(:publish)
         .with(instance_of(Moleculer::Packets::Event))
     end
@@ -28,7 +28,7 @@ RSpec.describe Moleculer::Broker::Publisher do
 
   describe "#publish_heartbeat" do
     it "publishes a heartbeat packet to the transporter" do
-      subject.publish_heartbeat
+      subject.heartbeat
       expect(transporter).to have_received(:publish)
         .with(instance_of(Moleculer::Packets::Heartbeat))
     end
@@ -36,7 +36,7 @@ RSpec.describe Moleculer::Broker::Publisher do
 
   describe "#publish_discover" do
     it "publishes an discover packet to the transporter" do
-      subject.publish_discover
+      subject.discover
       expect(transporter).to have_received(:publish)
         .with(instance_of(Moleculer::Packets::Discover))
     end
@@ -44,7 +44,7 @@ RSpec.describe Moleculer::Broker::Publisher do
 
   describe "#publish_discover_to_node_id" do
     it "publishes an discover packet to the transporter" do
-      subject.publish_discover_to_node_id("test")
+      subject.discover_to_node_id("test")
       expect(transporter).to have_received(:publish)
         .with(instance_of(Moleculer::Packets::Discover))
     end
@@ -52,7 +52,7 @@ RSpec.describe Moleculer::Broker::Publisher do
 
   describe "#publish_info" do
     it "publishes an info packet to the transporter" do
-      subject.publish_info
+      subject.info
       expect(transporter).to have_received(:publish)
         .with(instance_of(Moleculer::Packets::Info))
     end
@@ -60,7 +60,7 @@ RSpec.describe Moleculer::Broker::Publisher do
 
   describe "#publish_req" do
     it "publishes an info packet to the transporter" do
-      subject.publish_req(id: "anid", action: "test", data: {}, meta: {}, params: {})
+      subject.req(id: "anid", action: "test", data: {}, meta: {}, params: {})
       expect(transporter).to have_received(:publish)
         .with(instance_of(Moleculer::Packets::Req))
     end
@@ -68,7 +68,7 @@ RSpec.describe Moleculer::Broker::Publisher do
 
   describe "#publish_res" do
     it "publishes an info packet to the transporter" do
-      subject.publish_res(id: "anid", success: true, data: {}, meta: {})
+      subject.res(id: "anid", success: true, data: {}, meta: {})
       expect(transporter).to have_received(:publish)
         .with(instance_of(Moleculer::Packets::Res))
     end

--- a/spec/moleculer/broker/publisher_spec.rb
+++ b/spec/moleculer/broker/publisher_spec.rb
@@ -7,18 +7,46 @@ RSpec.describe Moleculer::Broker::Publisher do
   let(:broker) do
     double(Moleculer::Broker,
            config:      Moleculer::Configuration.new,
-           transporter: transporter)
+           transporter: transporter,
+           logger:      double(Moleculer::Support::LogProxy, trace: true),
+           registry:    double(Moleculer::Registry, local_node: double(Moleculer::Node,
+                                                                       id:   "test",
+                                                                       to_h: { services: [], hostname: "" })))
   end
 
   subject { Moleculer::Broker::Publisher.new(broker) }
 
   describe "#publish_event" do
-    let(:event) { { event: "test.event", data: {}, broadcast: false} }
+    let(:event) { { event: "test.event", data: {}, broadcast: false } }
 
     it "publishes an event packet to the transporter" do
       subject.publish_event(event)
       expect(transporter).to have_received(:publish)
         .with(instance_of(Moleculer::Packets::Event))
+    end
+  end
+
+  describe "#publish_heartbeat" do
+    it "publishes a heartbeat packet to the transporter" do
+      subject.publish_heartbeat
+      expect(transporter).to have_received(:publish)
+        .with(instance_of(Moleculer::Packets::Heartbeat))
+    end
+  end
+
+  describe "#publish_discover" do
+    it "publishes an discover packet to the transporter" do
+      subject.publish_heartbeat
+      expect(transporter).to have_received(:publish)
+        .with(instance_of(Moleculer::Packets::Discover))
+    end
+  end
+
+  describe "#publish_info" do
+    it "publishes an info packet to the transporter" do
+      subject.publish_info
+      expect(transporter).to have_received(:publish)
+        .with(instance_of(Moleculer::Packets::Info))
     end
   end
 end

--- a/spec/moleculer/broker/publisher_spec.rb
+++ b/spec/moleculer/broker/publisher_spec.rb
@@ -36,7 +36,15 @@ RSpec.describe Moleculer::Broker::Publisher do
 
   describe "#publish_discover" do
     it "publishes an discover packet to the transporter" do
-      subject.publish_heartbeat
+      subject.publish_discover
+      expect(transporter).to have_received(:publish)
+        .with(instance_of(Moleculer::Packets::Discover))
+    end
+  end
+
+  describe "#publish_discover_to_node_id" do
+    it "publishes an discover packet to the transporter" do
+      subject.publish_discover_to_node_id("test")
       expect(transporter).to have_received(:publish)
         .with(instance_of(Moleculer::Packets::Discover))
     end
@@ -47,6 +55,22 @@ RSpec.describe Moleculer::Broker::Publisher do
       subject.publish_info
       expect(transporter).to have_received(:publish)
         .with(instance_of(Moleculer::Packets::Info))
+    end
+  end
+
+  describe "#publish_req" do
+    it "publishes an info packet to the transporter" do
+      subject.publish_req({})
+      expect(transporter).to have_received(:publish)
+        .with(instance_of(Moleculer::Packets::Req))
+    end
+  end
+
+  describe "#publish_res" do
+    it "publishes an info packet to the transporter" do
+      subject.publish_res(id: "anid", success: true, data: {}, meta: {})
+      expect(transporter).to have_received(:publish)
+        .with(instance_of(Moleculer::Packets::Res))
     end
   end
 end


### PR DESCRIPTION
Working towards supporting fault tolerance methods which uses middleware, I decided to clean up the large broker class by breaking down its components. This first PR is focused on breaking out publishing methods into its own helper class. Some processing logic has been broken out as well, and more of that will be done in subsequent PRs.